### PR TITLE
Send camera settings via HTTP

### DIFF
--- a/app/src/main/java/com/example/p2/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/p2/ui/main/MainScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -64,6 +65,9 @@ fun MainScreen() {
                         }
                     }) {
                         Icon(Icons.Default.CameraAlt, contentDescription = stringResource(R.string.capture))
+                    }
+                    IconButton(onClick = { capturedBitmap = null }) {
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.resume_stream))
                     }
                     IconButton(onClick = {
                         context.startActivity(

--- a/app/src/main/java/com/example/p2/ui/settings/CameraCommands.kt
+++ b/app/src/main/java/com/example/p2/ui/settings/CameraCommands.kt
@@ -6,9 +6,11 @@ import kotlin.concurrent.thread
 
 fun sendSetting(ip: String, variable: String, value: Int) {
     if (ip.isBlank()) return
+    val targetIp =
+        if (ip.startsWith("http://") || ip.startsWith("https://")) ip else "http://$ip"
     thread {
         try {
-            val url = URL("$ip/control?var=$variable&val=$value")
+            val url = URL("$targetIp/control?var=$variable&val=$value")
             val connection = url.openConnection() as HttpURLConnection
             connection.requestMethod = "GET"
             connection.connectTimeout = 2000

--- a/app/src/main/java/com/example/p2/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/example/p2/ui/settings/SettingsActivity.kt
@@ -16,9 +16,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.p2.R
 import com.example.p2.ui.theme.P2Theme
-import java.net.HttpURLConnection
-import java.net.URL
-import kotlin.concurrent.thread
 
 class SettingsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -123,22 +120,6 @@ fun SettingsScreen(ipAddress: String) {
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(stringResource(R.string.apply))
-        }
-    }
-}
-
-private fun sendSetting(ip: String, variable: String, value: Int) {
-    if (ip.isBlank()) return
-    thread {
-        try {
-            val url = URL("$ip/control?var=$variable&val=$value")
-            val conn = url.openConnection() as HttpURLConnection
-            conn.requestMethod = "GET"
-            conn.connectTimeout = 2000
-            conn.connect()
-            conn.inputStream.close()
-            conn.disconnect()
-        } catch (_: Exception) {
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="ip_address">Dirección IP</string>
     <string name="capture">Capturar</string>
     <string name="capture_done">Captura realizada</string>
+    <string name="resume_stream">Ver stream</string>
     <string name="settings">Configuraciones</string>
     <string name="register">Registrar</string>
     <string name="register_success">Registro guardado</string>


### PR DESCRIPTION
## Summary
- normalize IP addresses inside `sendSetting`
- send resolution, quality and brightness to camera when pressing Apply
- add a refresh button to resume streaming after capturing a frame

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a0797ce0832c8874be853ad6108a